### PR TITLE
🚀 RELEASE: v1.05

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Image digest
         run: |
           echo "One or more files in design folder changed in branch psreact18whatsnew"
-          RELEASEVERSION=1.04
+          RELEASEVERSION=1.05
           # RELEASEVERSION=$(cat version.txt)
           # https://github.community/t/wanting-to-add-a-build-date-and-time-to-my-github-action/220185/6'
           #

--- a/src/App.css
+++ b/src/App.css
@@ -13,8 +13,10 @@
 body {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  height: 100vh;
+  /* justify-content: center;
+  height: 100vh; */
+  margin: 2rem;
+  background-color: #e8ecf5;
 }
 
 .city--list, .city--details {
@@ -24,6 +26,7 @@ body {
   /* border: 1px solid rgba(0,0,0,.125); */
   box-shadow: 0px 7px 25px 10px rgb(129 129 129 / 16%);
   border-radius: 0.25rem !important;
+  background-color: #fff;
 }
 
 .city--details .list-group-horizontal > * {
@@ -62,4 +65,16 @@ body {
 
 .padding-fix {
   padding: 1rem 0.5rem ;
+}
+
+.list-group-item-action:active,
+.list-group-item-action:focus,
+.list-group-item-action:hover {
+  /* color: #212529; */
+  background-color: #f0f6ff;
+}
+
+.btn-group {
+  margin-bottom: 0.5rem;
+  gap: 2px;
 }

--- a/src/cityStuff/CityDetail.js
+++ b/src/cityStuff/CityDetail.js
@@ -49,15 +49,15 @@ function CityLocation() {
 export default function CityDetail() {
   return (
     <>
-      <Suspense fallback={<div className="padding-fix">Loading CityInfo...</div>}>
+      <Suspense fallback={<div className="list-group-item">Loading...</div>}>
         <CityInfo />
       </Suspense>
 
-      <Suspense fallback={<div className="padding-fix">Loading CityStats...</div>}>
+      <Suspense fallback={<div className="list-group-item">Loading...</div>}>
         <CityStats />
       </Suspense>
 
-      <Suspense fallback={<div className="padding-fix">Loading CityLocation...</div>}>
+      <Suspense fallback={<div className="list-group-item">Loading...</div>}>
         <CityLocation />
       </Suspense>
     </>

--- a/src/cityStuff/CityDisplayCount.js
+++ b/src/cityStuff/CityDisplayCount.js
@@ -4,7 +4,7 @@ import { CityListStoreContext } from "../CityListStoreContext";
 export default function CityDisplayCount() {
   const { setDisplayCount } = useContext(CityListStoreContext);
   return (
-    <div className="btn-group mb-2" role="group" aria-label="Basic example">
+    <div className="btn-group" role="group" aria-label="Basic example">
       <button
         type="button"
         className="btn btn-secondary"

--- a/src/cityStuff/CityListAndDetail.js
+++ b/src/cityStuff/CityListAndDetail.js
@@ -13,9 +13,9 @@ export default function CityListAndDetail() {
         <CityDisplayCount />
         {/* <CityHeader /> */}
         <div className="row">
-          <Suspense fallback={<div>Loading CityList...</div>}>
+          <Suspense fallback={<div>Loading...</div>}>
             <CityList>
-              <Suspense fallback={<div>Loading CityDetail...</div>}>
+              <Suspense fallback={<div>Loading...</div>}>
                 <CityDetail />
               </Suspense>
             </CityList>


### PR DESCRIPTION
In this release taken care of the following breaking issues. 

- [x] 1. permanently leave the "City list" and "City details" titles up and just replace the data area with the "Loading..." message.
- [x] 2. keep the titles area on the top from moving when the Loading messages appear. Just the data area should be replaced with the Loading message and the screen display should stay still (that is no motion vertically)
- [x] 3. in the city Details data area, make the loading message lines the same height as the data so that as they fill in, the loading messages disappear and the data stays in the same vertical positions.
- [x] 3. body background color change.